### PR TITLE
add bluebird >= 2.10.2 as a dependency

### DIFF
--- a/anydb-sql.js
+++ b/anydb-sql.js
@@ -199,7 +199,7 @@ module.exports.anydbSQL = function (opt) {
         return P.try(function() {
             return wrapTransaction(pool.begin());
         }).then(function(tx) {
-            return P.try(f, tx).then(function(res) {
+            return P.try(function() { return f(tx); }).then(function(res) {
                 if (tx._logQueries)
                     console.log("Commiting tx", tx._id, res);
                 return tx.commitAsync().thenReturn(res);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "any-db-mysql": "^2.1.2",
     "any-db-postgres": "^2.1.4",
     "any-db-transaction": "^2.2.2",
-    "bluebird": "^2.10.2",
+    "bluebird": ">= 2.10.2",
     "node-sql-2": "^0.78.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anydb-sql-2",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Minimal ORM for mysql, postgresql and sqlite with complete arbitrary SQL query support (based on brianc's query builder sql)",
   "main": "anydb-sql.js",
   "types": "d.ts/anydb-sql.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -115,9 +115,9 @@ blue-tape@^0.1.7:
   dependencies:
     tape ">=2.0.0 <5.0.0"
 
-bluebird@^2.10.2:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+"bluebird@>= 2.10.2":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
 boom@2.x.x:
   version "2.10.1"


### PR DESCRIPTION
Just update the dependency to any Bluebird above 2.10.2. Peer dependencies are controversial, it turns out.

Also fixes the use of `Promise.try` so that it no longer uses the deprecated version of Bluebird.

----

*Previous Idea*

The idea is that dependents of this module should be free to use any other compatible Bluebird version. Otherwise, all promises returned from anydb-sql-2 satisfy `instanceof` but they don't actually use the newer functionality from the project's Bluebird.

Added it as a devDependency so that developers can get the lowest supported dependency when developing.

Version is set to `2.2.0` so that new users of the package will have to satisfy Bluebird.