### PR TITLE
Fix connection depletion in testmode.

### DIFF
--- a/anydb-sql.js
+++ b/anydb-sql.js
@@ -342,9 +342,10 @@ module.exports.anydbSQL = function (opt) {
 
         if (val === true) {
             if (testMode) {
-                console.warn(lastTestMode.stack);
+                console.warn(lastTestMode && lastTestMode.stack);
                 let e = new Error('DB is already in test mode!');
-                return console.warn(e.stack)
+                console.warn(e.stack)
+                return P.resolve()
             }
             lastTestMode = new Error('Test mode was last activated here, but not de-activated:');
             testMode = true;
@@ -357,7 +358,8 @@ module.exports.anydbSQL = function (opt) {
             if (!testMode) {
                 console.warn(lastTestMode && lastTestMode.stack);
                 let e = new Error('DB not in test mode!');
-                return console.warn(e.stack);
+                console.warn(e.stack);
+                return P.resolve()
             }
             lastTestMode = new Error('Test mode deactivated here, but not re-activated');
 

--- a/anydb-sql.js
+++ b/anydb-sql.js
@@ -384,7 +384,7 @@ module.exports.anydbSQL = function (opt) {
         fakeTxnPool.testActive = false;
         const rollbackPromise = fakeTxnPool.rollbackAsync().catch((e) => {
             if (e.message.indexOf("method 'rollback' unavailable in state 'closed'") >= 0) {
-                console.log("anydb, test mode warning: can't reset test. Did you send broken SQL to the DB?")
+                console.log("anydb, test mode warning: can't reset test. Did you forget to wait for the promise returned by testReset,or send broken SQL to the DB?")
                 console.log(e.stack);
             } else {
                 throw e;

--- a/anydb-sql.js
+++ b/anydb-sql.js
@@ -306,15 +306,25 @@ module.exports.anydbSQL = function (opt) {
     function txWithoutSavepointCommits(tx) {
         const oldBegin = tx.begin;
 
+        tx.testActive = true;
         tx.begin = function() {
             const savepoint = oldBegin.call(this);
             savepoint.commitAsync = function() { return P.resolve(); };
             savepoint.rollbackAsync = function() { return P.resolve(); };
+
+            let oldQ = savepoint.queryAsync;
+
+            savepoint.queryAsync = function() {
+              if (tx.testActive) return oldQ.apply(this, arguments)
+              else throw new Error('Test mode was deactivated, but queries are still running!');
+            }
             return savepoint;
         }
 
         return tx;
     }
+
+    let lastTestMode = null;
 
     /**
      * When the DB is in test mode, `db.begin` doesn't create new transactions.
@@ -327,24 +337,38 @@ module.exports.anydbSQL = function (opt) {
      * -> commit: does nothing
      * -> rollback: is translated to RESTORE SAVEPOINT
      */
-    db.testMode = function(val) {
+    db.testMode = function (val) {
         if (val === void 0) val = true;
 
         if (val === true) {
             if (testMode) {
-                return console.warn('DB is already in test mode; ignoring.');
+                console.warn(lastTestMode.stack);
+                let e = new Error('DB is already in test mode!');
+                return console.warn(e.stack)
             }
+            lastTestMode = new Error('Test mode was last activated here, but not de-activated:');
             testMode = true;
             oldPool = pool;
             fakeTxnPool = txWithoutSavepointCommits(wrapTransaction(pool.begin()));
             db.setPool(fakeTxnPool);
+
+            return Promise.resolve()
         } else {
             if (!testMode) {
-                return console.warn('DB is not in test mode; ignoring.');
+                console.warn(lastTestMode && lastTestMode.stack);
+                let e = new Error('DB not in test mode!');
+                return console.warn(e.stack);
             }
-            db.setPool(oldPool);
-            fakeTxnPool = null;
-            testMode = false;
+            lastTestMode = new Error('Test mode deactivated here, but not re-activated');
+
+            return fakeTxnPool.rollbackAsync()
+                .finally(() => {
+                    fakeTxnPool.testActive = false;
+                    fakeTxnPool = null;
+                    testMode = false;
+                    db.setPool(oldPool);
+                })
+
         }
     }
 
@@ -355,9 +379,11 @@ module.exports.anydbSQL = function (opt) {
         if (!testMode) {
             throw new Error('DB is not in test mode')
         }
+        fakeTxnPool.testActive = false;
         const rollbackPromise = fakeTxnPool.rollbackAsync().catch((e) => {
             if (e.message.indexOf("method 'rollback' unavailable in state 'closed'") >= 0) {
                 console.log("anydb, test mode warning: can't reset test. Did you send broken SQL to the DB?")
+                console.log(e.stack);
             } else {
                 throw e;
             }

--- a/d.ts/anydb-sql.d.ts
+++ b/d.ts/anydb-sql.d.ts
@@ -252,7 +252,7 @@ declare module "anydb-sql-2" {
       close(): void;
       getPool(): AnyDBPool;
       setPool(pool: AnydbSql): void;
-      testMode(val: boolean): void;
+      testMode(val: boolean): Promise<void>;
       testReset(): Promise<void>;
       dialect(): string;
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "anydb-sql-2",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "description": "Minimal ORM for mysql, postgresql and sqlite with complete arbitrary SQL query support (based on brianc's query builder sql)",
   "main": "anydb-sql.js",
   "types": "d.ts/anydb-sql.d.ts",


### PR DESCRIPTION
Every time testMode(false) is called, the last transaction from the
testReset() stays open. This changes the API to ensure the last reset
also gets closed.