### PR TITLE
Remove params from query logging

### DIFF
--- a/anydb-sql.js
+++ b/anydb-sql.js
@@ -125,9 +125,8 @@ function create(opt) {
           function(res) {
             if (where._logQueries) {
               console.log(
-                'anydb-sql query complete: `' + query.text + '` with params',
-                query.values,
-                'in tx',
+                'anydb-sql query complete: `' + query.text +
+                '` in tx',
                 where._id,
                 'stack\n',
                 estack.stack
@@ -146,9 +145,7 @@ function create(opt) {
               query.text +
               '`' +
               ' in tx ' +
-              where._id +
-              ' with params ' +
-              JSON.stringify(query.values);
+              where._id;
             throw err;
           }
         )

--- a/test/index.js
+++ b/test/index.js
@@ -64,7 +64,7 @@ test('anydb-sql', function(t) {
 
     t.test('insert transaction', function(t) {
         return db.transaction(function(tx) {
-            tx.logQueries(true);
+
             return user.insert({id: 2, name: 'test2'}).execWithin(tx)
             .then(function() {
                 return user.insert({id: 3, name: 'test3'}).execWithin(tx);
@@ -151,11 +151,8 @@ test('anydb-sql', function(t) {
 
     t.test('tx savepoint', function(t) {
       let q = db.transaction(tx => {
-        tx.logQueries(true)
-        console.log("Loging queries");
 
         let sp = tx.begin();
-        console.log("Began TX");
         return sp.queryAsync('select * from users')
           .then(r => t.ok(r, 'should return some rows'))
           .then(() => sp.commitAsync());


### PR DESCRIPTION
Params can contain potentially sensitive data: its best they're removed from any content that can bubble up and be logged