### PR TITLE
Fix types and add extensive JSDoc to them

### DIFF
--- a/d.ts/anydb-sql.d.ts
+++ b/d.ts/anydb-sql.d.ts
@@ -64,6 +64,17 @@ interface Executable<T> {
   allWithin(tx: DatabaseConnection): Promise<T[]>;
   toQuery(): QueryLike;
 }
+type TupleUnion<C extends any[]> = C[keyof C & number];
+
+type ColumnNames<C extends any[]> = TupleUnion<
+  { [K in keyof C]: C[K] extends Column<infer Name, infer Value> ? Name : void }
+>;
+
+type FindColumnWithName<Name extends String, C extends Column<any, any>[]> = TupleUnion<
+  { [K in keyof C]: C[K] extends Column<Name, infer Value> ? Value : never }
+>;
+
+type RowOf<Cols extends any[]> = { [K in ColumnNamesUnion<Cols>]: FindColumnWithName<K, Cols> };
 
 interface Queryable<T> {
   where(...nodes: any[]): Query<T>;
@@ -79,6 +90,8 @@ interface Queryable<T> {
     n2: Column<N2, T2>,
     n3: Column<N3, T3>,
   ): Query<{ [N in N1]: T1 } & { [N in N2]: T2 } & { [N in N3]: T3 }>;
+
+  select<Cols extends Column<any, any>[]>(...cols: Cols): Query<RowOf<Cols>>;
   select<U>(...nodesOrTables: any[]): Query<U>;
 
   selectDeep<N1 extends string, T1>(n1: Table<N1, T1>): Query<T1>;


### PR DESCRIPTION
Fixes applied

* select can now take an unlimited number of columns
* column operators are significantly more type-safe
* count and sum have the right type and support type safe column names
* where conditions are more type safe than before, accepting only partial row objects or binary expressions